### PR TITLE
fix: set default keyboard device if none specified

### DIFF
--- a/src/config/config.c
+++ b/src/config/config.c
@@ -369,18 +369,20 @@ bongocat_error_t load_config(config_t *config, const char *config_file_path) {
     // Initialize with defaults
     config_set_defaults(config);
     
-    // Set default keyboard device if none specified
-    bongocat_error_t result = config_set_default_devices(config);
-    if (result != BONGOCAT_SUCCESS) {
-        bongocat_log_error("Failed to set default keyboard devices: %s", bongocat_error_string(result));
-        return result;
-    }
-    
     // Parse config file and override defaults
-    result = config_parse_file(config, config_file_path);
+    bongocat_error_t result = config_parse_file(config, config_file_path);
     if (result != BONGOCAT_SUCCESS) {
         bongocat_log_error("Failed to parse configuration file: %s", bongocat_error_string(result));
         return result;
+    }
+
+    // Set default keyboard device if none specified
+    if (config->keyboard_devices == NULL || config->num_keyboard_devices == 0) {
+        result = config_set_default_devices(config);
+        if (result != BONGOCAT_SUCCESS) {
+            bongocat_log_error("Failed to set default keyboard devices: %s", bongocat_error_string(result));
+            return result;
+        }
     }
     
     // Validate and sanitize configuration


### PR DESCRIPTION


Default device (`/dev/input/event4`) still get added even if I have only 2 devices in my list.
it should only be added if no devices is in the config, as a fallback.

##  Reproduce

1. setup devices in config, e.g. 3
2. start bongocat

You will have always one more device

## Setup

**config:**
```ini
keyboard_device=/dev/input/event7  # External bluetooth keyboard
keyboard_device=/dev/input/event5   # Another input device
```

## Output

**log:**
```bash
[2025-08-06 23:03:50.560] INFO: Input monitoring started on /dev/input/event4 (fd=6)
[2025-08-06 23:03:50.560] INFO: Input monitoring started on /dev/input/event7 (fd=8)
[2025-08-06 23:03:50.560] INFO: Input monitoring started on /dev/input/event5 (fd=9)
[2025-08-06 23:03:50.560] INFO: Successfully opened 3/3 input devices
```