### PR TITLE
added multi-monitor support, fixed some memory leaks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ result
 *.swp
 *.swo
 *~
+.idea/
 
 # Temporary files
 *.tmp

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.2.4] - 2025-08-08
+
+### Added
+- **Multi-Monitor Support** - Choose which monitor to display bongocat on using the `monitor` configuration option
+- **Monitor Detection** - Automatic detection of available monitors with fallback to first monitor if specified monitor not found
+- **XDG Output Protocol** - Proper Wayland protocol implementation for monitor identification
+
+### Fixed
+- **Memory Leaks** - Fixed memory leak in monitor configuration cleanup
+- **Process Cleanup** - Resolved child process cleanup warnings during shutdown
+- **Segmentation Fault** - Fixed crash during application exit related to Wayland resource cleanup
+
+### Improved
+- **Error Handling** - Better error messages when specified monitor is not found
+- **Resource Management** - Improved cleanup order for Wayland resources
+- **Logging** - Enhanced debug logging for monitor detection and selection
+
 ## [1.2.3] - 2025-08-02
 
 ### Added

--- a/Makefile
+++ b/Makefile
@@ -47,8 +47,8 @@ EMBEDDED_ASSETS_H = $(INCDIR)/graphics/embedded_assets.h
 EMBEDDED_ASSETS_C = $(SRCDIR)/graphics/embedded_assets.c
 
 # Protocol files
-C_PROTOCOL_SRC = $(PROTOCOLDIR)/zwlr-layer-shell-v1-protocol.c $(PROTOCOLDIR)/xdg-shell-protocol.c $(PROTOCOLDIR)/wlr-foreign-toplevel-management-v1-protocol.c
-H_PROTOCOL_HDR = $(PROTOCOLDIR)/zwlr-layer-shell-v1-client-protocol.h $(PROTOCOLDIR)/xdg-shell-client-protocol.h $(PROTOCOLDIR)/wlr-foreign-toplevel-management-v1-client-protocol.h
+C_PROTOCOL_SRC = $(PROTOCOLDIR)/zwlr-layer-shell-v1-protocol.c $(PROTOCOLDIR)/xdg-shell-protocol.c $(PROTOCOLDIR)/wlr-foreign-toplevel-management-v1-protocol.c $(PROTOCOLDIR)/xdg-output-unstable-v1-protocol.c
+H_PROTOCOL_HDR = $(PROTOCOLDIR)/zwlr-layer-shell-v1-client-protocol.h $(PROTOCOLDIR)/xdg-shell-client-protocol.h $(PROTOCOLDIR)/wlr-foreign-toplevel-management-v1-client-protocol.h $(PROTOCOLDIR)/xdg-output-unstable-v1-client-protocol.h
 PROTOCOL_OBJECTS = $(C_PROTOCOL_SRC:$(PROTOCOLDIR)/%.c=$(OBJDIR)/%.o)
 
 # Target executable
@@ -87,13 +87,15 @@ $(TARGET): $(OBJECTS) $(PROTOCOL_OBJECTS)
 	$(CC) $(OBJECTS) $(PROTOCOL_OBJECTS) -o $(TARGET) $(LDFLAGS)
 
 # Rule to generate Wayland protocol files
-$(C_PROTOCOL_SRC) $(H_PROTOCOL_HDR): $(PROTOCOLDIR)/wlr-layer-shell-unstable-v1.xml $(PROTOCOLDIR)/wlr-foreign-toplevel-management-unstable-v1.xml
+$(C_PROTOCOL_SRC) $(H_PROTOCOL_HDR): $(PROTOCOLDIR)/wlr-layer-shell-unstable-v1.xml $(PROTOCOLDIR)/wlr-foreign-toplevel-management-unstable-v1.xml $(PROTOCOLDIR)/xdg-output-unstable-v1.xml
 	wayland-scanner client-header $(WAYLAND_PROTOCOLS_DIR)/stable/xdg-shell/xdg-shell.xml $(PROTOCOLDIR)/xdg-shell-client-protocol.h
 	wayland-scanner private-code $(WAYLAND_PROTOCOLS_DIR)/stable/xdg-shell/xdg-shell.xml $(PROTOCOLDIR)/xdg-shell-protocol.c
 	wayland-scanner private-code $(PROTOCOLDIR)/wlr-layer-shell-unstable-v1.xml $(PROTOCOLDIR)/zwlr-layer-shell-v1-protocol.c
 	wayland-scanner client-header $(PROTOCOLDIR)/wlr-layer-shell-unstable-v1.xml $(PROTOCOLDIR)/zwlr-layer-shell-v1-client-protocol.h
 	wayland-scanner private-code $(PROTOCOLDIR)/wlr-foreign-toplevel-management-unstable-v1.xml $(PROTOCOLDIR)/wlr-foreign-toplevel-management-v1-protocol.c
 	wayland-scanner client-header $(PROTOCOLDIR)/wlr-foreign-toplevel-management-unstable-v1.xml $(PROTOCOLDIR)/wlr-foreign-toplevel-management-v1-client-protocol.h
+	wayland-scanner client-header $(PROTOCOLDIR)/xdg-output-unstable-v1.xml $(PROTOCOLDIR)/xdg-output-unstable-v1-client-protocol.h
+	wayland-scanner private-code $(PROTOCOLDIR)/xdg-output-unstable-v1.xml $(PROTOCOLDIR)/xdg-output-unstable-v1-protocol.c
 
 clean:
 	rm -rf $(BUILDDIR) $(C_PROTOCOL_SRC) $(H_PROTOCOL_HDR)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Bongo Cat Wayland Overlay
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](https://opensource.org/licenses/MIT)
-[![Version](https://img.shields.io/badge/version-1.2.3-blue.svg)](https://github.com/saatvik333/wayland-bongocat/releases)
+[![Version](https://img.shields.io/badge/version-1.2.4-blue.svg)](https://github.com/saatvik333/wayland-bongocat/releases)
 
 A delightful Wayland overlay that displays an animated bongo cat reacting to your keyboard input! Perfect for streamers, content creators, or anyone who wants to add some fun to their desktop.
 
@@ -15,6 +15,7 @@ A delightful Wayland overlay that displays an animated bongo cat reacting to you
 - **⚡ Performance Optimized** - Adaptive monitoring and batch processing (v1.2.0)
 - **🖥️ Screen Detection** - Automatic screen detection for all sizes and orientations (v1.2.2)
 - **🎮 Smart Fullscreen Detection** - Automatically hides during fullscreen applications (v1.2.3)
+- **🖥️ Multi-Monitor Support** - Choose which monitor to display on in multi-monitor setups (v1.2.4)
 - **💾 Lightweight** - Minimal resource usage (~7MB RAM)
 - **🎛️ Multi-device Support** - Monitor multiple keyboards simultaneously
 - **🏗️ Cross-platform** - Works on x86_64 and ARM64
@@ -145,6 +146,9 @@ test_animation_interval=3        # Test animation every N seconds (0=off)
 keyboard_device=/dev/input/event4
 keyboard_device=/dev/input/event20  # External/Bluetooth keyboard
 
+# Multi-monitor support
+monitor=eDP-1                    # Specify which monitor to display on (optional)
+
 # Debug
 enable_debug=1                   # Show debug messages
 ```
@@ -162,6 +166,7 @@ enable_debug=1                   # Show debug messages
 | `keypress_duration`       | Integer | 50-5000           | 100                 | Animation duration after keypress (ms)        |
 | `test_animation_interval` | Integer | 0-60              | 3                   | Test animation interval (seconds, 0=disabled) |
 | `keyboard_device`         | String  | Valid path        | `/dev/input/event4` | Input device path (multiple allowed)          |
+| `monitor`                 | String  | Monitor name      | Auto-detect         | Monitor to display on (e.g., "eDP-1", "HDMI-A-1") |
 | `enable_debug`            | Boolean | 0 or 1            | 0                   | Enable debug logging                          |
 
 ## 🔧 Usage
@@ -243,7 +248,7 @@ The `bongocat-find-devices` tool provides professional input device analysis wit
 $ bongocat-find-devices
 
 ╔══════════════════════════════════════════════════════════════════╗
-║ Wayland Bongo Cat - Input Device Discovery v1.2.3                ║
+║ Wayland Bongo Cat - Input Device Discovery v1.2.4                ║
 ╚══════════════════════════════════════════════════════════════════╝
 
 [SCAN] Scanning for input devices...
@@ -308,7 +313,7 @@ bongocat-find-devices --help
 - **Storage:** ~0.4MB executable size
 - **Compositor:** Wayland with layer shell protocol support
 
-### Performance Metrics (v1.2.3)
+### Performance Metrics (v1.2.4)
 
 - **Input Latency:** <1ms with batch processing
 - **CPU Usage:** <1% on modern systems
@@ -376,6 +381,39 @@ sudo evtest /dev/input/event4
 </details>
 
 <details>
+<summary>Multi-monitor setup issues</summary>
+
+**Finding monitor names:**
+
+```bash
+# Using wlr-randr (recommended)
+wlr-randr
+
+# Using swaymsg (Sway only)
+swaymsg -t get_outputs
+
+# Check bongocat logs for detected monitors
+bongocat --watch-config  # Look for "xdg-output name received" messages
+```
+
+**Configuration:**
+
+```ini
+# Specify exact monitor name
+monitor=eDP-1        # Laptop screen
+monitor=HDMI-A-1     # External HDMI monitor
+monitor=DP-1         # DisplayPort monitor
+```
+
+**Troubleshooting:**
+
+- If monitor name is wrong, bongocat falls back to first available monitor
+- Monitor names are case-sensitive
+- Remove or comment out `monitor=` line to use auto-detection
+
+</details>
+
+<details>
 <summary>Build errors</summary>
 
 **Common fixes:**
@@ -412,11 +450,12 @@ wayland-bongocat/
 └── nix/               # NixOS integration
 ```
 
-### Key Features (v1.2.3)
+### Key Features (v1.2.4)
 
 - **Screen Detection** -> Automatic screen width/orientation detection
 - **Fullscreen Detection** -> Smart hiding during fullscreen applications
 - **Enhanced Artwork** -> Custom-drawn animations with improved visual quality
+- **Multi-Monitor Support** -> Choose specific monitor for display in multi-monitor setups
 
 ## 🤝 Contributing
 
@@ -451,4 +490,4 @@ Built with ❤️ for the Wayland community. Special thanks to:
 
 ---
 
-**₍^. .^₎ Wayland Bongo Cat Overlay v1.2.3** - Making desktops more delightful, one keystroke at a time!
+**₍^. .^₎ Wayland Bongo Cat Overlay v1.2.4** - Making desktops more delightful, one keystroke at a time!

--- a/bongocat.conf
+++ b/bongocat.conf
@@ -57,5 +57,11 @@ enable_debug=0
 # Use keyboard_device for each device you want to monitor
 # Examples:
 keyboard_device=/dev/input/event4
-keyboard_device=/dev/input/event20  # External bluetooth keyboard
+# keyboard_device=/dev/input/event20  # External bluetooth keyboard (commented out - doesn't exist)
 # keyboard_device=/dev/input/event5   # Another input device
+
+# Multi-monitor support
+# Specify which monitor to display bongocat on (optional)
+# Use wlr-randr or swaymsg -t get_outputs to find monitor names
+# If not specified or monitor not found, uses first available monitor
+monitor = eDP-1

--- a/include/config/config.h
+++ b/include/config/config.h
@@ -38,6 +38,7 @@ typedef struct {
 
 bongocat_error_t load_config(config_t *config, const char *config_file_path);
 void config_cleanup(void);
+void config_cleanup_full(config_t *config);
 int get_screen_width(void);
 
 #endif // CONFIG_H

--- a/include/config/config.h
+++ b/include/config/config.h
@@ -16,6 +16,7 @@ typedef enum {
 
 typedef struct {
     int screen_width;
+    char *output_name;
     int bar_height;
     const char *asset_paths[NUM_FRAMES];
     char **keyboard_devices;

--- a/include/core/bongocat.h
+++ b/include/core/bongocat.h
@@ -23,7 +23,7 @@
 #include "../lib/stb_image.h"
 
 // Version
-#define BONGOCAT_VERSION "1.2.3"
+#define BONGOCAT_VERSION "1.2.4"
 
 // Common constants
 #define NUM_FRAMES 3

--- a/include/core/bongocat.h
+++ b/include/core/bongocat.h
@@ -29,6 +29,7 @@
 #define NUM_FRAMES 3
 #define DEFAULT_SCREEN_WIDTH 1920
 #define DEFAULT_BAR_HEIGHT 40
+#define MAX_OUTPUTS 8 // Maximum monitor outputs to store
 
 // Config watcher constants
 #define INOTIFY_EVENT_SIZE (sizeof(struct inotify_event))
@@ -43,6 +44,15 @@ typedef struct {
     char *config_path;
     void (*reload_callback)(const char *config_path);
 } ConfigWatcher;
+
+// Output monitor reference structure
+typedef struct {
+    struct wl_output *wl_output;
+    struct zxdg_output_v1 *xdg_output;
+    uint32_t name;         // Registry name
+    char name_str[128];   // From xdg-output
+    bool name_received;
+} output_ref_t;
 
 // Config watcher function declarations
 int config_watcher_init(ConfigWatcher *watcher, const char *config_path, void (*callback)(const char *));

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -8,7 +8,7 @@
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "wayland-bongocat";
-  version = "1.2.3";
+  version = "1.2.4";
   src = ../.;
 
   # Build toolchain and dependencies

--- a/protocols/xdg-output-unstable-v1.xml
+++ b/protocols/xdg-output-unstable-v1.xml
@@ -1,0 +1,222 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<protocol name="xdg_output_unstable_v1">
+
+    <copyright>
+        Copyright © 2017 Red Hat Inc.
+
+        Permission is hereby granted, free of charge, to any person obtaining a
+        copy of this software and associated documentation files (the "Software"),
+        to deal in the Software without restriction, including without limitation
+        the rights to use, copy, modify, merge, publish, distribute, sublicense,
+        and/or sell copies of the Software, and to permit persons to whom the
+        Software is furnished to do so, subject to the following conditions:
+
+        The above copyright notice and this permission notice (including the next
+        paragraph) shall be included in all copies or substantial portions of the
+        Software.
+
+        THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+        IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+        FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+        THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+        LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+        FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+        DEALINGS IN THE SOFTWARE.
+    </copyright>
+
+    <description summary="Protocol to describe output regions">
+        This protocol aims at describing outputs in a way which is more in line
+        with the concept of an output on desktop oriented systems.
+
+        Some information are more specific to the concept of an output for
+        a desktop oriented system and may not make sense in other applications,
+        such as IVI systems for example.
+
+        Typically, the global compositor space on a desktop system is made of
+        a contiguous or overlapping set of rectangular regions.
+
+        The logical_position and logical_size events defined in this protocol
+        might provide information identical to their counterparts already
+        available from wl_output, in which case the information provided by this
+        protocol should be preferred to their equivalent in wl_output. The goal is
+        to move the desktop specific concepts (such as output location within the
+        global compositor space, etc.) out of the core wl_output protocol.
+
+        Warning! The protocol described in this file is experimental and
+        backward incompatible changes may be made. Backward compatible
+        changes may be added together with the corresponding interface
+        version bump.
+        Backward incompatible changes are done by bumping the version
+        number in the protocol and interface names and resetting the
+        interface version. Once the protocol is to be declared stable,
+        the 'z' prefix and the version number in the protocol and
+        interface names are removed and the interface version number is
+        reset.
+    </description>
+
+    <interface name="zxdg_output_manager_v1" version="3">
+        <description summary="manage xdg_output objects">
+            A global factory interface for xdg_output objects.
+        </description>
+
+        <request name="destroy" type="destructor">
+            <description summary="destroy the xdg_output_manager object">
+                Using this request a client can tell the server that it is not
+                going to use the xdg_output_manager object anymore.
+
+                Any objects already created through this instance are not affected.
+            </description>
+        </request>
+
+        <request name="get_xdg_output">
+            <description summary="create an xdg output from a wl_output">
+                This creates a new xdg_output object for the given wl_output.
+            </description>
+            <arg name="id" type="new_id" interface="zxdg_output_v1"/>
+            <arg name="output" type="object" interface="wl_output"/>
+        </request>
+    </interface>
+
+    <interface name="zxdg_output_v1" version="3">
+        <description summary="compositor logical output region">
+            An xdg_output describes part of the compositor geometry.
+
+            This typically corresponds to a monitor that displays part of the
+            compositor space.
+
+            For objects version 3 onwards, after all xdg_output properties have been
+            sent (when the object is created and when properties are updated), a
+            wl_output.done event is sent. This allows changes to the output
+            properties to be seen as atomic, even if they happen via multiple events.
+        </description>
+
+        <request name="destroy" type="destructor">
+            <description summary="destroy the xdg_output object">
+                Using this request a client can tell the server that it is not
+                going to use the xdg_output object anymore.
+            </description>
+        </request>
+
+        <event name="logical_position">
+            <description summary="position of the output within the global compositor space">
+                The position event describes the location of the wl_output within
+                the global compositor space.
+
+                The logical_position event is sent after creating an xdg_output
+                (see xdg_output_manager.get_xdg_output) and whenever the location
+                of the output changes within the global compositor space.
+            </description>
+            <arg name="x" type="int"
+                 summary="x position within the global compositor space"/>
+            <arg name="y" type="int"
+                 summary="y position within the global compositor space"/>
+        </event>
+
+        <event name="logical_size">
+            <description summary="size of the output in the global compositor space">
+                The logical_size event describes the size of the output in the
+                global compositor space.
+
+                Most regular Wayland clients should not pay attention to the
+                logical size and would rather rely on xdg_shell interfaces.
+
+                Some clients such as Xwayland, however, need this to configure
+                their surfaces in the global compositor space as the compositor
+                may apply a different scale from what is advertised by the output
+                scaling property (to achieve fractional scaling, for example).
+
+                For example, for a wl_output mode 3840×2160 and a scale factor 2:
+
+                - A compositor not scaling the monitor viewport in its compositing space
+                will advertise a logical size of 3840×2160,
+
+                - A compositor scaling the monitor viewport with scale factor 2 will
+                advertise a logical size of 1920×1080,
+
+                - A compositor scaling the monitor viewport using a fractional scale of
+                1.5 will advertise a logical size of 2560×1440.
+
+                For example, for a wl_output mode 1920×1080 and a 90 degree rotation,
+                the compositor will advertise a logical size of 1080x1920.
+
+                The logical_size event is sent after creating an xdg_output
+                (see xdg_output_manager.get_xdg_output) and whenever the logical
+                size of the output changes, either as a result of a change in the
+                applied scale or because of a change in the corresponding output
+                mode(see wl_output.mode) or transform (see wl_output.transform).
+            </description>
+            <arg name="width" type="int"
+                 summary="width in global compositor space"/>
+            <arg name="height" type="int"
+                 summary="height in global compositor space"/>
+        </event>
+
+        <event name="done" deprecated-since="3">
+            <description summary="all information about the output have been sent">
+                This event is sent after all other properties of an xdg_output
+                have been sent.
+
+                This allows changes to the xdg_output properties to be seen as
+                atomic, even if they happen via multiple events.
+
+                For objects version 3 onwards, this event is deprecated. Compositors
+                are not required to send it anymore and must send wl_output.done
+                instead.
+            </description>
+        </event>
+
+        <!-- Version 2 additions -->
+
+        <event name="name" since="2">
+            <description summary="name of this output">
+                Many compositors will assign names to their outputs, show them to the
+                user, allow them to be configured by name, etc. The client may wish to
+                know this name as well to offer the user similar behaviors.
+
+                The naming convention is compositor defined, but limited to
+                alphanumeric characters and dashes (-). Each name is unique among all
+                wl_output globals, but if a wl_output global is destroyed the same name
+                may be reused later. The names will also remain consistent across
+                sessions with the same hardware and software configuration.
+
+                Examples of names include 'HDMI-A-1', 'WL-1', 'X11-1', etc. However, do
+                not assume that the name is a reflection of an underlying DRM
+                connector, X11 connection, etc.
+
+                The name event is sent after creating an xdg_output (see
+                xdg_output_manager.get_xdg_output). This event is only sent once per
+                xdg_output, and the name does not change over the lifetime of the
+                wl_output global.
+
+                This event is deprecated, instead clients should use wl_output.name.
+                Compositors must still support this event.
+            </description>
+            <arg name="name" type="string" summary="output name"/>
+        </event>
+
+        <event name="description" since="2">
+            <description summary="human-readable description of this output">
+                Many compositors can produce human-readable descriptions of their
+                outputs.  The client may wish to know this description as well, to
+                communicate the user for various purposes.
+
+                The description is a UTF-8 string with no convention defined for its
+                contents. Examples might include 'Foocorp 11" Display' or 'Virtual X11
+                output via :1'.
+
+                The description event is sent after creating an xdg_output (see
+                xdg_output_manager.get_xdg_output) and whenever the description
+                changes. The description is optional, and may not be sent at all.
+
+                For objects of version 2 and lower, this event is only sent once per
+                xdg_output, and the description does not change over the lifetime of
+                the wl_output global.
+
+                This event is deprecated, instead clients should use
+                wl_output.description. Compositors must still support this event.
+            </description>
+            <arg name="description" type="string" summary="output description"/>
+        </event>
+
+    </interface>
+</protocol>

--- a/scripts/find_input_devices.sh
+++ b/scripts/find_input_devices.sh
@@ -1,6 +1,6 @@
 # Wayland Bongo Cat - Input Device Discovery Tool
 # Professional input device finder with comprehensive analysis
-# Version: 1.2.0
+# Version: 1.2.4
 
 set -euo pipefail
 
@@ -51,7 +51,7 @@ readonly TEST="[TEST]"
 
 # Script metadata
 readonly SCRIPT_NAME="bongocat-find-devices"
-readonly VERSION="1.2.0"
+readonly VERSION="1.2.4"
 
 # Command line options
 SHOW_ALL=false
@@ -80,6 +80,11 @@ usage() {
         printf "    This tool scans your system for input devices and provides configuration\n"
         printf "    suggestions for Wayland Bongo Cat. It identifies keyboards, checks\n"
         printf "    permissions, and generates ready-to-use configuration snippets.\n\n"
+        printf "${WHITE}MONITOR DETECTION:${NC}\n"
+        printf "    For multi-monitor setups, use these commands to find monitor names:\n"
+        printf "    • wlr-randr                    # List all monitors (recommended)\n"
+        printf "    • swaymsg -t get_outputs       # Sway compositor only\n"
+        printf "    • bongocat logs show detected monitors during startup\n\n"
     else
         cat << EOF
 ${SCRIPT_NAME} v${VERSION}
@@ -104,6 +109,12 @@ DESCRIPTION:
     This tool scans your system for input devices and provides configuration
     suggestions for Wayland Bongo Cat. It identifies keyboards, checks
     permissions, and generates ready-to-use configuration snippets.
+
+MONITOR DETECTION:
+    For multi-monitor setups, use these commands to find monitor names:
+    • wlr-randr                    # List all monitors (recommended)
+    • swaymsg -t get_outputs       # Sway compositor only
+    • bongocat logs show detected monitors during startup
 
 EOF
     fi

--- a/src/config/config.c
+++ b/src/config/config.c
@@ -186,7 +186,16 @@ static bongocat_error_t config_parse_integer_key(config_t *config, const char *k
         config->overlay_opacity = int_value;
     } else if (strcmp(key, "enable_debug") == 0) {
         config->enable_debug = int_value;
-    } else {
+    } else if (strcmp(key, "monitor") == 0) {
+        // Reallocate new name for monitor output
+        config->output_name = realloc(config->output_name, strlen(value) + 1);
+        if (!config->output_name) {
+            bongocat_log_error("Failed to allocate memory for interface output");
+            return BONGOCAT_ERROR_MEMORY;
+        }
+        strcpy(config->output_name, value);
+    }
+    else {
         return BONGOCAT_ERROR_INVALID_PARAM; // Unknown key
     }
     
@@ -305,6 +314,7 @@ static bongocat_error_t config_parse_file(config_t *config, const char *config_f
 static void config_set_defaults(config_t *config) {
     *config = (config_t) {
         .screen_width = DEFAULT_SCREEN_WIDTH,  // Will be updated by Wayland detection
+        .output_name = NULL, // Will default to automatic one if kept null
         .bar_height = DEFAULT_BAR_HEIGHT,
         .asset_paths = {
             "assets/bongo-cat-both-up.png",

--- a/src/config/config.c
+++ b/src/config/config.c
@@ -415,6 +415,17 @@ void config_cleanup(void) {
     config_cleanup_devices();
 }
 
+void config_cleanup_full(config_t *config) {
+    if (!config) return;
+    
+    config_cleanup_devices();
+    
+    if (config->output_name) {
+        free(config->output_name);
+        config->output_name = NULL;
+    }
+}
+
 int get_screen_width(void) {
     // This function is now only used for initial config loading
     // The actual screen width detection happens in wayland_init

--- a/src/config/config.c
+++ b/src/config/config.c
@@ -369,18 +369,20 @@ bongocat_error_t load_config(config_t *config, const char *config_file_path) {
     // Initialize with defaults
     config_set_defaults(config);
     
-    // Set default keyboard device if none specified
-    bongocat_error_t result = config_set_default_devices(config);
-    if (result != BONGOCAT_SUCCESS) {
-        bongocat_log_error("Failed to set default keyboard devices: %s", bongocat_error_string(result));
-        return result;
-    }
-    
     // Parse config file and override defaults
-    result = config_parse_file(config, config_file_path);
+    bongocat_error_t result = config_parse_file(config, config_file_path);
     if (result != BONGOCAT_SUCCESS) {
         bongocat_log_error("Failed to parse configuration file: %s", bongocat_error_string(result));
         return result;
+    }
+
+    // Set default keyboard device if none specified
+    if (config->keyboard_devices == NULL || config->num_keyboard_devices == 0) {
+        result = config_set_default_devices(config);
+        if (result != BONGOCAT_SUCCESS) {
+            bongocat_log_error("Failed to set default keyboard devices: %s", bongocat_error_string(result));
+            return result;
+        }
     }
     
     // Validate and sanitize configuration

--- a/src/platform/input.c
+++ b/src/platform/input.c
@@ -287,8 +287,14 @@ bongocat_error_t input_restart_monitoring(char **device_paths, int num_devices, 
                 bongocat_log_debug("Previous input monitoring process terminated");
                 break;
             } else if (result == -1) {
-                bongocat_log_warning("Error waiting for input child process: %s", strerror(errno));
-                break;
+                if (errno == ECHILD) {
+                    // Child already reaped by signal handler - this is normal
+                    bongocat_log_debug("Input child process already cleaned up by signal handler");
+                    break;
+                } else {
+                    bongocat_log_warning("Error waiting for input child process: %s", strerror(errno));
+                    break;
+                }
             }
             
             usleep(100000); // Wait 100ms
@@ -357,8 +363,14 @@ void input_cleanup(void) {
                 bongocat_log_debug("Input monitoring child process terminated gracefully");
                 break;
             } else if (result == -1) {
-                bongocat_log_warning("Error waiting for input child process: %s", strerror(errno));
-                break;
+                if (errno == ECHILD) {
+                    // Child already reaped by signal handler - this is normal
+                    bongocat_log_debug("Input child process already cleaned up by signal handler");
+                    break;
+                } else {
+                    bongocat_log_warning("Error waiting for input child process: %s", strerror(errno));
+                    break;
+                }
             }
             
             usleep(100000); // Wait 100ms


### PR DESCRIPTION
### Added
- **Multi-Monitor Support** - Choose which monitor to display bongocat on using the `monitor` configuration option
- **Monitor Detection** - Automatic detection of available monitors with fallback to first monitor if specified monitor not found
- **XDG Output Protocol** - Proper Wayland protocol implementation for monitor identification
