### PR TITLE
Draft: reload config with signal

### DIFF
--- a/include/core/bongocat.h
+++ b/include/core/bongocat.h
@@ -39,6 +39,7 @@
 typedef struct {
     int inotify_fd;
     int watch_fd;
+    int signal_fd;
     pthread_t watcher_thread;
     bool watching;
     char *config_path;
@@ -55,7 +56,7 @@ typedef struct {
 } output_ref_t;
 
 // Config watcher function declarations
-int config_watcher_init(ConfigWatcher *watcher, const char *config_path, void (*callback)(const char *));
+int config_watcher_init(ConfigWatcher *watcher, int signal_fd, const char *config_path, void (*callback)(const char *));
 void config_watcher_start(ConfigWatcher *watcher);
 void config_watcher_stop(ConfigWatcher *watcher);
 void config_watcher_cleanup(ConfigWatcher *watcher);

--- a/include/platform/wayland.h
+++ b/include/platform/wayland.h
@@ -22,8 +22,10 @@ extern uint8_t *pixels;
 extern bool configured;
 extern bool fullscreen_detected;
 
+typedef void (*config_reload_callback_t)();
+
 bongocat_error_t wayland_init(config_t *config);
-bongocat_error_t wayland_run(volatile sig_atomic_t *running);
+bongocat_error_t wayland_run(volatile sig_atomic_t *running, int signal_fd, config_reload_callback_t config_reload_callback);
 void wayland_cleanup(void);
 void wayland_update_config(config_t *config);
 void draw_bar(void);


### PR DESCRIPTION
Alternative for `--watch-config`, sending a `SIGURS2` to bongocat, reloads it (current) config. _Similar behavior to waybar_

* add `SIGUSR2` signal handling
* move signal handling into `wayland_run` (use pool)

## Test

1. start `bongocat`
2. send signal `pkill --signal SIGUSR2 bongocat`

## Problems

Now I had to change the signal handling (move signal handling into `wayland_run`), because the rendering buffer broke.

After that I still have a problem, after triggering reload:
```bash
[2025-08-11 12:38:35.234] INFO: Received SIGUSR2, reloading config
[2025-08-11 12:38:35.234] INFO: Reloading configuration from: (null)
[2025-08-11 12:38:35.234] INFO: Loaded configuration from bongocat.conf
=================================================================
==553258==ERROR: AddressSanitizer: heap-use-after-free on address 0x7c1ff59e0030 at pc 0x555555612b5d bp 0x7fffffffde10 sp 0x7fffffffde00
READ of size 8 at 0x7c1ff59e0030 thread T0
    #0 0x555555612b5c in config_devices_changed src/core/main.c:167
    #1 0x555555612f7a in config_reload_callback src/core/main.c:194
    #2 0x5555556132d3 in current_config_reload_callback src/core/main.c:227
    #3 0x55555561a083 in wayland_run src/platform/wayland.c:695
    #4 0x555555614e2d in main src/core/main.c:484
    #5 0x7ffff6c27674  (/usr/lib/libc.so.6+0x27674) (BuildId: 1d7c9b9187cec4c03a504fccc917f9af55568a53)
    #6 0x7ffff6c27728 in __libc_start_main (/usr/lib/libc.so.6+0x27728) (BuildId: 1d7c9b9187cec4c03a504fccc917f9af55568a53)
    #7 0x55555560f8f4 in _start (build/bongocat+0xbb8f4) (BuildId: f476b1b7e9ec8aeff7c0e35fd1e9e9af996ca4da)

0x7c1ff59e0030 is located 0 bytes inside of 8-byte region [0x7c1ff59e0030,0x7c1ff59e0038)
freed by thread T0 here:
    #0 0x7ffff791f79d in free /usr/src/debug/gcc/gcc/libsanitizer/asan/asan_malloc_linux.cpp:51
    #1 0x555555690a1e in config_cleanup_devices src/config/config.c:141
    #2 0x555555693afc in load_config src/config/config.c:377
    #3 0x555555612f12 in config_reload_callback src/core/main.c:185
    #4 0x5555556132d3 in current_config_reload_callback src/core/main.c:227
    #5 0x55555561a083 in wayland_run src/platform/wayland.c:695
    #6 0x555555614e2d in main src/core/main.c:484
    #7 0x7ffff6c27674  (/usr/lib/libc.so.6+0x27674) (BuildId: 1d7c9b9187cec4c03a504fccc917f9af55568a53)
    #8 0x7ffff6c27728 in __libc_start_main (/usr/lib/libc.so.6+0x27728) (BuildId: 1d7c9b9187cec4c03a504fccc917f9af55568a53)
    #9 0x55555560f8f4 in _start (build/bongocat+0xbb8f4) (BuildId: f476b1b7e9ec8aeff7c0e35fd1e9e9af996ca4da)

previously allocated by thread T0 here:
    #0 0x7ffff791fa45 in realloc /usr/src/debug/gcc/gcc/libsanitizer/asan/asan_malloc_linux.cpp:81
    #1 0x5555556902ed in config_add_keyboard_device src/config/config.c:112
    #2 0x555555691dc1 in config_parse_key_value src/config/config.c:244
    #3 0x555555692326 in config_parse_file src/config/config.c:289
    #4 0x555555693b1b in load_config src/config/config.c:383
    #5 0x555555614c1e in main src/core/main.c:459
    #6 0x7ffff6c27674  (/usr/lib/libc.so.6+0x27674) (BuildId: 1d7c9b9187cec4c03a504fccc917f9af55568a53)
    #7 0x7ffff6c27728 in __libc_start_main (/usr/lib/libc.so.6+0x27728) (BuildId: 1d7c9b9187cec4c03a504fccc917f9af55568a53)
    #8 0x55555560f8f4 in _start (/mnt/data/abeimler/Dokumente/Projects/wayland-digimon/build/bongocat+0xbb8f4) (BuildId: f476b1b7e9ec8aeff7c0e35fd1e9e9af996ca4da)

SUMMARY: AddressSanitizer: heap-use-after-free src/core/main.c:167 in config_devices_changed
Shadow bytes around the buggy address:
  0x7c1ff59dfd80: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x7c1ff59dfe00: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x7c1ff59dfe80: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x7c1ff59dff00: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x7c1ff59dff80: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
=>0x7c1ff59e0000: fa fa fd fd fa fa[fd]fa fa fa 06 fa fa fa fd fd
  0x7c1ff59e0080: fa fa fd fd fa fa 00 06 fa fa fd fd fa fa fd fd
  0x7c1ff59e0100: fa fa fd fd fa fa 00 06 fa fa 00 06 fa fa fd fd
  0x7c1ff59e0180: fa fa fd fd fa fa fd fd fa fa fd fd fa fa fd fd
  0x7c1ff59e0200: fa fa fd fd fa fa fd fd fa fa fd fd fa fa fd fd
  0x7c1ff59e0280: fa fa fd fd fa fa fd fd fa fa fd fd fa fa fd fd
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
==553258==ABORTING

```

Seems like the `old_config->keyboard_devices` is invalid or "losses" the old reference of the devices (property to reallocation ?), as of `config_keyboard_devices` is a global and gets shared devices with old and new config.