### PR TITLE
feat: add option to disable random frame selection (#49)

### DIFF
--- a/bongocat.conf
+++ b/bongocat.conf
@@ -44,6 +44,9 @@ overlay_position=top
 # 0 = both paws up, 1 = left paw down, 2 = right paw down, 3 = both paw down
 idle_frame=0
 
+# enable_random_frame: When on random frame selection when typing, | 0 = off, 1 = on
+enable_random_frame=1
+
 # Sleep Mode settings
 # enable_scheduled_sleep: When on, animations will be paused and show sleep frame (0 = off, 1 = on)
 # Requires both sleep_begin and sleep_end to be defined

--- a/include/config/config.h
+++ b/include/config/config.h
@@ -54,6 +54,8 @@ typedef struct {
     config_time_t sleep_end;
     int idle_sleep_timeout_sec;
     align_type_t cat_align;
+
+    int enable_random_frame;
 } config_t;
 
 bongocat_error_t load_config(config_t *config, const char *config_file_path);

--- a/src/config/config.c
+++ b/src/config/config.c
@@ -107,6 +107,7 @@ static bongocat_error_t config_validate(config_t *config) {
     // Normalize boolean values
     config->enable_debug = config->enable_debug ? 1 : 0;
     config->enable_scheduled_sleep = config->enable_scheduled_sleep ? 1 : 0;
+    config->enable_random_frame = config->enable_random_frame ? 1 : 0;
 
     config_validate_dimensions(config);
     config_validate_timing(config);
@@ -216,6 +217,8 @@ static bongocat_error_t config_parse_integer_key(config_t *config, const char *k
         config->enable_scheduled_sleep = int_value;
     } else if (strcmp(key, "idle_sleep_timeout") == 0) {
         config->idle_sleep_timeout_sec = int_value;
+    } else if (strcmp(key, "enable_random_frame") == 0) {
+        config->enable_random_frame = int_value;
     } else {
         return BONGOCAT_ERROR_INVALID_PARAM; // Unknown key
     }
@@ -421,8 +424,8 @@ static void config_set_defaults(config_t *config) {
         .test_animation_interval = 0,
         .fps = 60,
         .overlay_opacity = 150,
-    .mirror_x = 0,
-    .mirror_y = 0,
+        .mirror_x = 0,
+        .mirror_y = 0,
         .enable_antialiasing = 1,
         .enable_debug = 1,
         .layer = LAYER_TOP,  // Default to TOP for broader compatibility
@@ -432,6 +435,7 @@ static void config_set_defaults(config_t *config) {
         .sleep_begin = (config_time_t){0, 0},
         .sleep_end = (config_time_t){0, 0},
         .idle_sleep_timeout_sec = 0,
+        .enable_random_frame = 1,
     };
 }
 

--- a/src/graphics/animation.c
+++ b/src/graphics/animation.c
@@ -203,6 +203,18 @@ static int anim_get_random_active_frame(void) {
     return (rand() % 2) + 1; // Frame 1 or 2 (active frames)
 }
 
+static int anim_get_next_active_frame(void) {
+    // toggle frames
+    if (anim_index == BONGOCAT_FRAME_LEFT_DOWN) {
+        return BONGOCAT_FRAME_RIGHT_DOWN;
+    }
+    if (anim_index == BONGOCAT_FRAME_RIGHT_DOWN) {
+        return BONGOCAT_FRAME_LEFT_DOWN;
+    }
+
+    return anim_get_random_active_frame();
+}
+
 static void anim_trigger_frame_change(int new_frame, long duration_us, long current_time_us,
                                      animation_state_t *state) {
     if (current_config->enable_debug) {
@@ -220,7 +232,7 @@ static void anim_handle_test_animation(animation_state_t *state, long current_ti
 
     state->test_counter++;
     if (state->test_counter > state->test_interval_frames) {
-        int new_frame = anim_get_random_active_frame();
+        int new_frame = (current_config->enable_random_frame) ? anim_get_random_active_frame() : anim_get_next_active_frame();
         long duration_us = current_config->test_animation_duration * 1000;
 
         bongocat_log_debug("Test animation trigger");
@@ -235,7 +247,7 @@ static void anim_handle_key_press(animation_state_t *state, long current_time_us
     }
 
     if (!current_config->enable_scheduled_sleep || !anim_is_sleep_time(current_config)) {
-        int new_frame = anim_get_random_active_frame();
+        int new_frame = (current_config->enable_random_frame) ? anim_get_random_active_frame() : anim_get_next_active_frame();
         long duration_us = current_config->keypress_duration * 1000;
 
         bongocat_log_debug("Key press detected - switching to frame %d", new_frame);


### PR DESCRIPTION
I added a new option `enable_random_frame` with the default value: `1`, to keep it the old behavior.