### PR TITLE
fix: multi-monitor switch

### DIFF
--- a/include/platform/wayland.h
+++ b/include/platform/wayland.h
@@ -63,6 +63,9 @@ BONGOCAT_NODISCARD int create_shm(int size);
 // Get detected screen width
 BONGOCAT_NODISCARD int wayland_get_screen_width(void);
 
+// Get detected output name
+BONGOCAT_NODISCARD const char *wayland_get_output_name(void);
+
 // Get current layer name for logging
 BONGOCAT_NODISCARD const char *wayland_get_current_layer_name(void);
 


### PR DESCRIPTION
Hello, I encountered an bug the other day because I have a multi-monitor set up and one of them as a with of `1980` and the other `2560`.
Because of the single `screen_info` variable and the unfortunate event firering, the wrong `screen_width` got set.

I also added the same "monitor reconnect" logic in config update, when switching monitors and update `screen_width.`

## My Setup

- 3 Monitors
  - `HDMI-A-1`: 1920x1080
  - `DP-1`: 2560x1440
  - `DP-2`: 2560x1440
- WM: hyprland
- Bongocat Version: 1.3.2 (latest)

### 1. Test case: Wrong `screen_width`

- no `monitor` option set
- no `screen_width` option set

Got always defaulted to `1920`, if I turn off the monitor the right screen_info got set.

### 2. Test case: Switch Monitors (new)

1. set `monitor=HDMI-A-1`
2. start bongocat with config watch
3. set `monitor=DP-1`
4. set `monitor=DP-3`
5. back to `monitor=HDMI-A-1`

_try to switch between monitors with different resolutions_

---

I sometimes had some issues with the `current_config->screen_with`, because I couldn't determent if it was an "old" value, default value or new value.
Added `screen_infos` similar to `outputs` and store the current `output`/`screen_info` for comparing `output name`, `screen_width` etc.
So on every `output_geometry`, the `screen_infos` gets updated for every screen and picked up later the right `screen_width`.
Buffers should been recreated after updating the `screen_info` + `screen_width` (reconnecting, changing monitors, and screen_width in options)

I hope I got every possible case tested with my multi-monitor setup 😀, bongocat seems to  work fine if you have one monitor and few workspaces, but the moment you have multi-monitor setup and multiple workspaces for every monitor it gets messy.

I still have to test and fix some bugs when fullscreening, sometimes the bongocat hides and sometimes it reappears #38 