### PR TITLE
fix(nix): only access _bongocat config when module is enabled

### DIFF
--- a/nix/home-module.nix
+++ b/nix/home-module.nix
@@ -4,10 +4,12 @@
   pkgs,
   ...
 }: let
-  inherit (config._bongocat) cfg configFile;
+  cfg = config.programs.wayland-bongocat;
 in {
   imports = [./common.nix];
-  config = lib.mkIf cfg.enable {
+  config = lib.mkIf cfg.enable (let
+    configFile = config._bongocat.configFile;
+  in {
     home.packages = [
       cfg.package
 
@@ -38,5 +40,5 @@ in {
         RestartSec = "5s";
       };
     };
-  };
+  });
 }

--- a/nix/nixos-module.nix
+++ b/nix/nixos-module.nix
@@ -6,10 +6,12 @@
   ...
 }:
 with lib; let
-  inherit (config._bongocat) cfg configFile;
+  cfg = config.programs.wayland-bongocat;
 in {
   imports = [./common.nix];
-  config = lib.mkIf cfg.enable {
+  config = lib.mkIf cfg.enable (let
+    configFile = config._bongocat.configFile;
+  in {
     environment.systemPackages = [
       cfg.package
 
@@ -35,5 +37,5 @@ in {
         RestartSec = "5s";
       };
     };
-  };
+  });
 }


### PR DESCRIPTION
Fixes error when nix module is imported but not enabled - was trying to inherit from config._bongocat unconditionally, which is empty {} when programs.wayland-bongocat.enable = false.

This was causing configurations that imported the module but left it disabled to fail to build.