### PR TITLE
Fix: add dependency checks for wayland-scanner, wayland-protocols, and xxd

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ TARGET = $(BUILDDIR)/bongocat
 
 .PHONY: all clean protocols embed-assets
 
-all: protocols embed-assets $(TARGET)
+all: embed-assets $(TARGET)
 
 # Generate protocol files first
 protocols: $(C_PROTOCOL_SRC) $(H_PROTOCOL_HDR)
@@ -90,6 +90,8 @@ $(TARGET): $(OBJECTS) $(PROTOCOL_OBJECTS)
 
 # Rule to generate Wayland protocol files
 $(C_PROTOCOL_SRC) $(H_PROTOCOL_HDR): $(PROTOCOLDIR)/wlr-layer-shell-unstable-v1.xml $(PROTOCOLDIR)/wlr-foreign-toplevel-management-unstable-v1.xml
+	@if ! command -v wayland-scanner &>/dev/null; then echo "ERROR: wayland-scanner not found. Install: sudo pacman -S wayland"; exit 1; fi
+	@if [ ! -f $(WAYLAND_PROTOCOLS_DIR)/stable/xdg-shell/xdg-shell.xml ]; then echo "ERROR: xdg-shell.xml not found. Install: sudo pacman -S wayland-protocols"; exit 1; fi
 	wayland-scanner client-header $(WAYLAND_PROTOCOLS_DIR)/stable/xdg-shell/xdg-shell.xml $(PROTOCOLDIR)/xdg-shell-client-protocol.h
 	wayland-scanner private-code $(WAYLAND_PROTOCOLS_DIR)/stable/xdg-shell/xdg-shell.xml $(PROTOCOLDIR)/xdg-shell-protocol.c
 	wayland-scanner private-code $(PROTOCOLDIR)/wlr-layer-shell-unstable-v1.xml $(PROTOCOLDIR)/zwlr-layer-shell-v1-protocol.c

--- a/scripts/embed_assets.sh
+++ b/scripts/embed_assets.sh
@@ -1,5 +1,12 @@
 # Script to convert PNG assets to C header files for embedding
 
+# Dependency check
+if ! command -v xxd &>/dev/null; then
+    echo "ERROR: xxd is required but not found." >&2
+    echo "Install it with: sudo pacman -S xxd" >&2
+    exit 1
+fi
+
 ASSETS_DIR="assets"
 OUTPUT_DIR="include/graphics"
 OUTPUT_FILE="$OUTPUT_DIR/embedded_assets.h"


### PR DESCRIPTION
## Problem

The AUR build of bongocat fails intermittently with `Makefile:108: release -> Error 2` when the following packages are missing from the build system:

- `wayland-scanner` (from the `wayland` package)
- `xdg-shell.xml` (from the `wayland-protocols` package)
- `xxd` (used by `scripts/embed_assets.sh` to embed PNG assets)

These are not caught early — the build simply fails with a cryptic error at `Makefile:108`.

## Changes

1. **Makefile**: Added pre-build checks for `wayland-scanner` and `xdg-shell.xml` in the protocol generation rule, with clear error messages telling the user exactly which package to install.

2. **scripts/embed_assets.sh**: Added `xxd` availability check with a clear error message.

3. **Makefile**: Removed `protocols` from the default `all` target. The generated protocol files are already committed to the repository, so forcing regeneration on every build is unnecessary and causes failures when timestamps trigger re-generation.

## Testing

The generated protocol files (`*-protocol.c`, `*-protocol.h`) are present in the repository and build correctly with the existing toolchain. The checks only run when regeneration is actually needed.

Fixes the intermittent AUR build failure (https://aur.archlinux.org/packages/bongocat)